### PR TITLE
BOJ 17196 Cow Steeplechase II 풀이 오류

### DIFF
--- a/_posts/2019-10-16-problems.md
+++ b/_posts/2019-10-16-problems.md
@@ -12,43 +12,6 @@ tags: [chat]
 
 ## set에 다항식 넣기
 
-### [17196: Cow Steeplechase II](https://www.acmicpc.net/problem/17196)  
-
-선분이 N개 주어집니다. 단 하나의 선분을 제거하면, 어떤 선분쌍도 교차하지 않음이 보장됩니다. 제거해야 하는 선분은?
-
-x축 정렬하고 스위핑 합니다.
-
-선분의 시작점을 만나면 set에 넣고, 끝점을 만나면 set에서 뺍니다.
-
-i번째 선분을 `a[i] = { sx,sy, ex,ey }`라고 합시다.
-
-* 선분의 시작점을 만나면: (`a[i]`, `a[i].sy`에서 위로 가장 가까운 선분), (`a[i]`, `a[i].sy`에서 아래로 가장 가까운 선분) 두 쌍을 교차판정 합니다.
-
-* 선분의 끝점을 만나면: (`a[i].ey`에서 위로 가장 가까운 선분, `a[i].ey`에서 아래로 가장 가까운 선분) 한 쌍을 교차판정 합니다.
-
-관리 중인 선분들의 x에서의 y좌표를 알기 위해서, set operator로 `f(x) = ax+b` 식을 정리해서 직선처럼 관리합니다.
-
-교차하는 순간 교차하는 두 선분 중에 둘 중 하나가 답입니다.
-
-어떤 두 선분이 교차하면 부분 순서가 깨지기 때문에 바로 break 합니다.
-
-반대로 얘기하면, 교차하지 않으면 부분 순서는 깨지지 않습니다.
-
-```cpp
-int n, cur_x;
-struct line {
-    int idx;
-    pll u, v;
-    double ypos(pll u, pll v)const {
-        if (v.fst == u.fst) return u.snd;
-        return u.snd+((double)v.snd-u.snd)*(cur_x-u.fst)/(v.fst-u.fst);
-    }
-    bool operator <(line a)const {
-        return (idx != a.idx) && (ypos(u, v) < ypos(a.u, a.v));
-    }
-} a[111111];
-```
-
 ### [17026: Mountain View](https://www.acmicpc.net/problem/17026)  
 
 1사분면에 `(x, y)`를 꼭짓점으로 하는 직각 이등변 삼각형이 `N`개 주어지고, 꼭짓점이 다른 삼각형에 포함되지 않는 것의 개수를 세는 문제입니다.  


### PR DESCRIPTION
USACO 문제는 원래 데이터가 약한 것이 좀 많습니다.

이제는 오류를 인정하고 풀이를 삭제해 주시기 바랍니다.